### PR TITLE
Physical compatibility between PinTypes allowed

### DIFF
--- a/Applications/Connectatron/Connectatron.cpp
+++ b/Applications/Connectatron/Connectatron.cpp
@@ -458,10 +458,26 @@ struct Connectatron:
         return false;
     }
 
+
+    /*bool IsCompatiblePin(Pin* a, Pin* b)
+    {
+        if (a->IsFemale)
+            return IsCompatiblePinType(b->Type, a->Type);
+        else
+            return IsCompatiblePinType(b->Type, a->Type);
+    }*/
+
     bool CanCreateLink(Pin* a, Pin* b)
     {
-        if (!a || !b || a == b || a->Kind == b->Kind || a->Type != b->Type || a->Node.lock() == b->Node.lock())
+        if (!a || !b || a == b || a->Kind == b->Kind || a->Node.lock() == b->Node.lock())
             return false;
+
+        if (a->IsFemale)
+            if (!IsCompatiblePinType(b->Type, a->Type))
+                return false;
+        else
+            if(!IsCompatiblePinType(b->Type, a->Type))
+                return false;
 
         return true;
     }
@@ -632,7 +648,9 @@ struct Connectatron:
         case PinType::HDMI:                     return IM_COLOR_MAGENTA;
         case PinType::Mini__HDMI:                 return IM_COLOR_MAGENTA;
         case PinType::Micro__HDMI:                return IM_COLOR_MAGENTA;
-        case PinType::DVI:                      return IM_COLOR_MAGENTA;
+        case PinType::DVI___D:                      return IM_COLOR_MAGENTA;
+        case PinType::DVI___A:                      return IM_COLOR_MAGENTA;
+        case PinType::DVI___I:                      return IM_COLOR_MAGENTA;
         case PinType::VGA:                      return IM_COLOR_MAGENTA;
 
             //Audio                             
@@ -728,7 +746,9 @@ struct Connectatron:
         case PinType::HDMI:                     iconType = IconType::Grid; break;
         case PinType::Mini__HDMI:                 iconType = IconType::Grid; break;
         case PinType::Micro__HDMI:                iconType = IconType::Grid; break;
-        case PinType::DVI:                      iconType = IconType::Grid; break;
+        case PinType::DVI___D:                      iconType = IconType::Grid; break;
+        case PinType::DVI___A:                      iconType = IconType::Grid; break;
+        case PinType::DVI___I:                      iconType = IconType::Grid; break;
         case PinType::VGA:                      iconType = IconType::Grid; break;
 
             //Audio                                 
@@ -1983,6 +2003,7 @@ struct Connectatron:
                             std::swap(startPin, endPin);
                             std::swap(startPinId, endPinId);
                         }
+                        // We ensure that the startPin is output/male
 
                         if (startPin && endPin)
                         {
@@ -2000,7 +2021,7 @@ struct Connectatron:
                             //    showLabel("x Cannot connect to self", ImColor(45, 32, 32, 180));
                             //    ed::RejectNewItem(ImColor(255, 0, 0), 1.0f);
                             //}
-                            else if (endPin->Type != startPin->Type)
+                            else if (!IsCompatiblePinType(startPin->Type, endPin->Type))
                             {
                                 showLabel("x Incompatible Pin Type", ImColor(45, 32, 32, 180));
                                 ed::RejectNewItem(ImColor(255, 128, 128), 1.0f);
@@ -2401,7 +2422,7 @@ struct Connectatron:
                                 case PinKind::Input: // Will be connecting to a female pin on new node
                                     for (const auto& pin : temp_node->Females)
                                     {
-                                        if (pin.Type == valid_type)
+                                        if (IsCompatiblePinType(valid_type, pin.Type))
                                         {
                                             this_node_is_valid = true;
                                             break;
@@ -2411,7 +2432,7 @@ struct Connectatron:
                                 case PinKind::Output: // Will be connecting to a male pin on new node
                                     for (const auto& pin : temp_node->Males)
                                     {
-                                        if (pin.Type == valid_type)
+                                        if (IsCompatiblePinType(pin.Type, valid_type))
                                         {
                                             this_node_is_valid = true;
                                             break;
@@ -2561,16 +2582,6 @@ struct Connectatron:
     ImTextureID          m_RestoreIcon = nullptr;
     // Connector type icons
     map<PinType, ImTextureID> connectorIcons;
-    /*ImTextureID          m_dp = nullptr;
-    ImTextureID          m_mini_dp = nullptr;
-    ImTextureID          m_hdmi = nullptr;
-    ImTextureID          m_mini_dvi = nullptr;
-    ImTextureID          m_vga = nullptr;
-    ImTextureID          m_ps2 = nullptr;
-    ImTextureID          m_rj11 = nullptr;
-    ImTextureID          m_rj25 = nullptr;
-    ImTextureID          m_toslink = nullptr;
-    ImTextureID          m_usb_mini_b = nullptr;*/
 
     const float          m_TouchTime = 1.0f;
     std::map<ed::NodeId, float, NodeIdLess> m_NodeTouchTime;

--- a/Applications/Connectatron/Connectors.h
+++ b/Applications/Connectatron/Connectors.h
@@ -26,9 +26,7 @@ enum class PinType
 
     // USB          // https://en.wikipedia.org/wiki/USB
     USB___A,
-    //USB___A__SuperSpeed, 
-    //NOTE: PinType does not discriminate between USB-A and USB-A SuperSpeed, even though they have 
-    //   additional pins, as they physically fit together and have at least some backward compatibility.
+    USB___A__SuperSpeed, // Has more pins for USB3 features. Fits with USB-A.
     USB___B,
     USB___B__SuperSpeed, // Has more pins for USB3 features. Taller than USB-B.
     USB___C,
@@ -48,11 +46,10 @@ enum class PinType
     HDMI,
     Mini__HDMI,
     Micro__HDMI,
-    DVI,            // https://en.wikipedia.org/wiki/Digital_Visual_Interface
-    //NOTE: DVI-I male connectors cannot be inserted into DVI-D female connectors,
-    //   but the opposite works fine. For this reason, I keep DVI as one connector
-    //   type for physical compatibility logic. The variants are sorted out in
-    //   the selection of supported protocols.
+    // https://en.wikipedia.org/wiki/Digital_Visual_Interface
+    DVI___D,
+    DVI___A,
+    DVI___I,
     Mini___DVI,     // https://en.wikipedia.org/wiki/Mini-DVI
     Micro___DVI,    // https://en.wikipedia.org/wiki/Micro-DVI
     VGA,
@@ -122,7 +119,9 @@ const map<PinType, string> connectorIconFiles
     {PinType::HDMI,                          "data/ic_hdmi.png"},
     {PinType::Mini__HDMI,                    ""},
     {PinType::Micro__HDMI,                   ""},
-    {PinType::DVI,                           ""},
+    {PinType::DVI___D,                       ""},
+    {PinType::DVI___A,                       ""},
+    {PinType::DVI___I,                       ""},
     {PinType::Mini___DVI,                    "data/ic_mini_dvi.jpg"},
     {PinType::Micro___DVI,                   ""},
     {PinType::VGA,                           "data/ic_vga.jpg"},
@@ -150,3 +149,82 @@ const map<PinType, string> connectorIconFiles
     {PinType::RJ25,                          ""},
     {PinType::RJ45,                          "data/ic_rj45.jpg"},
 };
+
+//TODO reinstate and update this if necessary.
+//static set<PinType> GetCompatibleMalePinTypes(PinType femaletype)
+//{
+//    set<PinType> ret;
+//    ret.insert(femaletype);
+//
+//    switch (femaletype)
+//    {
+//        //Power
+//
+//        //USB                               
+//    case PinType::USB___A:
+//        ret.insert(PinType::USB___A__SuperSpeed);
+//        break;
+//    case PinType::USB___A__SuperSpeed:
+//        ret.insert(PinType::USB___A);
+//        break;
+//
+//        //Display             
+//        //NOTE: DVI-I male connectors cannot be inserted into DVI-D female connectors,
+//        //   but the opposite works fine.              
+//    case PinType::DVI___I:
+//        ret.insert(PinType::DVI___D);
+//        break;
+//        //Audio                             
+//
+//        //Other                             
+//
+//    default:
+//        break;
+//    }
+//
+//    return ret;
+//}
+
+static set<PinType> GetCompatibleFemalePinTypes(PinType maletype)
+{
+    set<PinType> ret;
+    ret.insert(maletype);
+
+    switch (maletype)
+    {
+        //Power
+
+        //USB                               
+    case PinType::USB___A:
+        ret.insert(PinType::USB___A__SuperSpeed);
+        break;
+    case PinType::USB___A__SuperSpeed:
+        ret.insert(PinType::USB___A);
+        break;
+
+        //Display                           
+        //NOTE: DVI-I male connectors cannot be inserted into DVI-D female connectors,
+        //   but DVI-D male connectors can be inserted into DVI-I female connectors.              
+    case PinType::DVI___D:
+        ret.insert(PinType::DVI___I);
+        break;
+        //Audio                             
+
+        //Other                             
+
+    default:
+        break;
+    }
+
+    return ret;
+}
+
+// Order of male vs female inputs matters!
+static bool IsCompatiblePinType(PinType male, PinType female)
+{
+    auto candidates = GetCompatibleFemalePinTypes(male);
+    if (candidates.find(female) != candidates.end())
+        return true;
+    else
+        return false;
+}

--- a/Applications/Connectatron/Protocols.h
+++ b/Applications/Connectatron/Protocols.h
@@ -253,3 +253,4 @@ static string NameFromProtocol(WireProtocol proto)
     EnumName_Underscore2Symbol(ret);
     return ret;
 }
+


### PR DESCRIPTION
Can even do odd things like only allow it for particular arrangements of male/female, and removing compatibility with the same connector-standard (maybe if that standard only defines a female or male connector; using a different standard for the other side of the connection).